### PR TITLE
Backend: try redis.asyncio package instead of redis

### DIFF
--- a/asgi.py
+++ b/asgi.py
@@ -4,7 +4,7 @@ from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
-from .transcendence.redis_client import _redis_client
+from transcendence.redis_client import _redis_client
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "transcendence.settings")
 

--- a/asgi.py
+++ b/asgi.py
@@ -4,6 +4,7 @@ from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
+from .transcendence.redis_client import _redis_client
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "transcendence.settings")
 
@@ -13,11 +14,31 @@ django_asgi_app = get_asgi_application()
 
 import transcendence.routing
 
+async def lifespan_scope(scope, receive, send):
+    """
+    Handle application lifespan events
+    """
+
+    if scope['type'] == 'lifespan':
+        while True:
+            message = await receive()
+            if message['type'] == 'lifespan.startup':
+                 # Do some startup
+                await send({'type': 'lifespan.startup.complete'})
+            elif message['type'] == 'lifespan.shutdown':
+                # Do some shutdown
+                await _redis_client.close() # close the redis connection pool
+                await send({'type': 'lifespan.shutdown.complete'})
+                return
+    else:
+        pass
+
 application = ProtocolTypeRouter(
     {
         "http": django_asgi_app,
         "websocket": AllowedHostsOriginValidator(
             AuthMiddlewareStack(URLRouter(transcendence.routing.websocket_urlpatterns))
         ),
+        "lifespan": lifespan_scope,
     }
 )

--- a/transcendence/lobby_consumers.py
+++ b/transcendence/lobby_consumers.py
@@ -57,7 +57,7 @@ class LobbyConsumer(AsyncWebsocketConsumer):
                     self.joined_group = ["room"]
                     await self.channel_layer.group_send(self.room_group_name, event=event_join_room)
                     joined_room = await data.get_one_room_data(room_id=room_id)
-                    if joined_room:
+                    if joined_room is not None:
                         await self.send(text_data=json.dumps({"type": "ack_join_room", "single_room_data": joined_room}))
                     else:
                         await self.send(text_data=json.dumps({"type": "ack_join_room", "single_room_data": "Cannot find the room to join!"}))

--- a/transcendence/lobby_consumers.py
+++ b/transcendence/lobby_consumers.py
@@ -33,7 +33,7 @@ class LobbyConsumer(AsyncWebsocketConsumer):
             case {"type": "init", "player_id": player_id}:
                 self.player_id = player_id # save who the player is
                 if player_id:
-                    room_list = data.get_full_room_data()
+                    room_list = await data.get_full_room_data()
                     await self.send(text_data=json.dumps({"type": "ack_init", "rooms": room_list}))
             case {"type": "join_room",  "room_id": room_id, "player_id": player_id}:
                 self.room_group_name = room_id
@@ -42,8 +42,8 @@ class LobbyConsumer(AsyncWebsocketConsumer):
                     self.lobby_group_name,
                     self.channel_name
 				)
-                if data.add_player_to_room(room_id=room_id, player_id=player_id):
-                    avatar = data.get_one_player(player_id=player_id)
+                if await data.add_player_to_room(room_id=room_id, player_id=player_id):
+                    avatar = await data.get_one_player(player_id=player_id)
                     if avatar is not None:
                         event_join_room = {"type": "join.room", "room_id": room_id, "avatar": avatar}
                     else:
@@ -56,7 +56,7 @@ class LobbyConsumer(AsyncWebsocketConsumer):
                     )
                     self.joined_group = ["room"]
                     await self.channel_layer.group_send(self.room_group_name, event=event_join_room)
-                    joined_room = data.get_one_room_data(room_id=room_id)
+                    joined_room = await data.get_one_room_data(room_id=room_id)
                     if joined_room:
                         await self.send(text_data=json.dumps({"type": "ack_join_room", "single_room_data": joined_room}))
                     else:
@@ -67,13 +67,13 @@ class LobbyConsumer(AsyncWebsocketConsumer):
                     self.lobby_group_name,
                     self.channel_name
 				)
-                added_room = data.add_new_room(room_id=room_id, owner_id=owner_id)
+                added_room = await data.add_new_room(room_id=room_id, owner_id=owner_id)
                 await self.channel_layer.group_add(
                         self.room_group_name,
                         self.channel_name
                 )
                 self.joined_group = ["room"]
-                owner_avatar = data.get_one_player(player_id=owner_id)
+                owner_avatar = await data.get_one_player(player_id=owner_id)
                 if owner_avatar is not None:
                     event_add_room = {"type": "add.room", "room_id": room_id, "owner_avatar": owner_avatar}
                 else:

--- a/transcendence/redis_client.py
+++ b/transcendence/redis_client.py
@@ -1,0 +1,10 @@
+import asyncio
+import redis.asyncio as redis
+
+_redis_client = None
+
+async def get_redis_client():
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis.Redis(host='db_redis', port=6379, db=0)
+    return _redis_client

--- a/transcendence/redis_data.py
+++ b/transcendence/redis_data.py
@@ -1,5 +1,6 @@
 import json
 import redis
+from .redis_client import get_redis_client
 from channels.generic.websocket import AsyncWebsocketConsumer
 
 # Connect to Redis
@@ -49,7 +50,8 @@ player_data_sample = [
 ]
 redis_instance.set("player_data", json.dumps(player_data_sample))
 
-def get_full_room_data() -> list:
+async def get_full_room_data() -> list:
+	redis_instance = await get_redis_client()
 	room_data = json.loads(redis_instance.get("room_data"))
 	player_data = json.loads(redis_instance.get("player_data"))
 
@@ -70,7 +72,8 @@ def get_full_room_data() -> list:
 
 	return full_room_data
 
-def add_player_to_room(room_id, player_id) -> bool:
+async def add_player_to_room(room_id, player_id) -> bool:
+	redis_instance = await get_redis_client()
 
 	room_data = json.loads(redis_instance.get("room_data"))
 	player_data = json.loads(redis_instance.get("player_data"))
@@ -93,7 +96,8 @@ def add_player_to_room(room_id, player_id) -> bool:
 		print(f"Room with room_id {room_id} not found in room_data.")
 		return False
 
-def get_one_room_data(room_id):
+async def get_one_room_data(room_id):
+    redis_instance = await get_redis_client()
 
     room_data = json.loads(redis_instance.get("room_data"))
 
@@ -102,7 +106,9 @@ def get_one_room_data(room_id):
 
     return room
 
-def add_new_room(room_id, owner_id) -> dict:
+async def add_new_room(room_id, owner_id) -> dict:
+    redis_instance = await get_redis_client()
+
     room_data = json.loads(redis_instance.get("room_data") or '[]')
 
     # Create a new room with default settings
@@ -125,7 +131,8 @@ def add_new_room(room_id, owner_id) -> dict:
 
     return new_room
 
-def get_one_player(player_id) -> dict|None:
+async def get_one_player(player_id) -> dict|None:
+    redis_instance = await get_redis_client()
     player_data = json.loads(redis_instance.get("player_data"))
 
     one_player = next((player for player in player_data if player["player_id"] == player_id), None)

--- a/transcendence/redis_data.py
+++ b/transcendence/redis_data.py
@@ -52,8 +52,8 @@ redis_instance.set("player_data", json.dumps(player_data_sample))
 
 async def get_full_room_data() -> list:
 	redis_instance = await get_redis_client()
-	room_data = json.loads(redis_instance.get("room_data"))
-	player_data = json.loads(redis_instance.get("player_data"))
+	room_data = json.loads(await redis_instance.get("room_data"))
+	player_data = json.loads(await redis_instance.get("player_data"))
 
 	player_data_dict = {player["player_id"]: player for player in player_data}
 
@@ -75,8 +75,8 @@ async def get_full_room_data() -> list:
 async def add_player_to_room(room_id, player_id) -> bool:
 	redis_instance = await get_redis_client()
 
-	room_data = json.loads(redis_instance.get("room_data"))
-	player_data = json.loads(redis_instance.get("player_data"))
+	room_data = json.loads(await redis_instance.get("room_data"))
+	player_data = json.loads(await redis_instance.get("player_data"))
 
 	# Find the player details from player_data
 	new_player = next((player for player in player_data if player["player_id"] == player_id), None)
@@ -91,7 +91,7 @@ async def add_player_to_room(room_id, player_id) -> bool:
 			if room["room_id"] == room_id:
 				room["avatars"].append({"player_id": new_player["player_id"]})
 				print(f"Player {player_id} added to {room['room_id']}.")
-				redis_instance.set("room_data", json.dumps(room_data))
+				await redis_instance.set("room_data", json.dumps(room_data))
 				return True
 		print(f"Room with room_id {room_id} not found in room_data.")
 		return False
@@ -99,7 +99,7 @@ async def add_player_to_room(room_id, player_id) -> bool:
 async def get_one_room_data(room_id):
     redis_instance = await get_redis_client()
 
-    room_data = json.loads(redis_instance.get("room_data"))
+    room_data = json.loads(await redis_instance.get("room_data"))
 
     # Find the room by room_id
     room = next((room for room in room_data if room["room_id"] == room_id), None)
@@ -109,7 +109,7 @@ async def get_one_room_data(room_id):
 async def add_new_room(room_id, owner_id) -> dict:
     redis_instance = await get_redis_client()
 
-    room_data = json.loads(redis_instance.get("room_data") or '[]')
+    room_data = json.loads(await redis_instance.get("room_data") or '[]')
 
     # Create a new room with default settings
     new_room = {
@@ -127,13 +127,13 @@ async def add_new_room(room_id, owner_id) -> dict:
 
     room_data.append(new_room)
 
-    redis_instance.set("room_data", json.dumps(room_data))
+    await redis_instance.set("room_data", json.dumps(room_data))
 
     return new_room
 
 async def get_one_player(player_id) -> dict|None:
     redis_instance = await get_redis_client()
-    player_data = json.loads(redis_instance.get("player_data"))
+    player_data = json.loads(await redis_instance.get("player_data"))
 
     one_player = next((player for player in player_data if player["player_id"] == player_id), None)
 


### PR DESCRIPTION
Manage redis_client in connection pool as a global/singleton in redis_client.py.
Define the function for manipulating redis with async prefix.
Inside the function, use the following to set redis connection:
```python
redis_instance = await get_redis_client()
```
To close async redis correctly, use lifespan protocol in asgi.py.